### PR TITLE
Fix Lenovo ACPI mistake.

### DIFF
--- a/drivers/input/i8042prt/pnp.c
+++ b/drivers/input/i8042prt/pnp.c
@@ -3,7 +3,7 @@
  * LICENSE:     GPL - See COPYING in the top level directory
  * FILE:        drivers/input/i8042prt/pnp.c
  * PURPOSE:     IRP_MJ_PNP operations
- * PROGRAMMERS: Copyright 2006-2007 Hervé Poussineau (hpoussin@reactos.org)
+ * PROGRAMMERS: Copyright 2006-2007 HervÃ© Poussineau (hpoussin@reactos.org)
  *              Copyright 2008 Colin Finck (mail@colinfinck.de)
  */
 
@@ -418,6 +418,7 @@ StartProcedure(
         i8042DetectMouse(DeviceExtension);
         TRACE_(I8042PRT, "Detecting keyboard\n");
         i8042DetectKeyboard(DeviceExtension);
+        i8042Write(DeviceExtension, DeviceExtension->ControlPort, 0xae);
 
         INFO_(I8042PRT, "Keyboard present: %s\n", DeviceExtension->Flags & KEYBOARD_PRESENT ? "YES" : "NO");
         INFO_(I8042PRT, "Mouse present   : %s\n", DeviceExtension->Flags & MOUSE_PRESENT ? "YES" : "NO");


### PR DESCRIPTION
## Purpose

Fix Lenovo ACPI mistake when keyboard is not initializing.

JIRA issue: [CORE-14256](https://jira.reactos.org/browse/CORE-14256)

## Proposed changes

Sends 0xae to i8042 command register. SHOULD NOT AFFECT NON-PROBLEM MOTHERBOARDS!
